### PR TITLE
Allow `out` variance for Updater

### DIFF
--- a/src/main/kotlin/io/github/snarks/reactivestore/cache/CacheSink.kt
+++ b/src/main/kotlin/io/github/snarks/reactivestore/cache/CacheSink.kt
@@ -3,7 +3,7 @@ package io.github.snarks.reactivestore.cache
 import io.github.snarks.reactivestore.utils.Loader
 import io.github.snarks.reactivestore.utils.Updater
 
-interface CacheSink<T> {
+interface CacheSink<in T> {
 	fun update(updater: Updater<T>)
 }
 
@@ -27,10 +27,8 @@ fun <T> CacheSink<T>.reload(customLoader: Loader<T>? = null, ignoreIfUpdated: Bo
 	update(Updater.reload(customLoader, ignoreIfUpdated))
 }
 
-fun <T> CacheSink<T>.cancelLoad() {
-	update(Updater.cancelLoad())
+fun <T> CacheSink<T>.revert() {
+	update(Updater.revert())
 }
 
-fun <T> CacheSink<T>.resetError() {
-	update(Updater.resetError())
-}
+// TODO mapping functions

--- a/src/main/kotlin/io/github/snarks/reactivestore/store/SimpleStore.kt
+++ b/src/main/kotlin/io/github/snarks/reactivestore/store/SimpleStore.kt
@@ -40,7 +40,7 @@ class SimpleStore<K, V>(
 		return makeSingle { map.asSequence().associate { (k, v) -> k to v.status } }
 	}
 
-	override fun currentFor(key: K): Single<Status<V>> = makeSingle { map[key]?.status ?: Empty() }
+	override fun currentFor(key: K): Single<Status<V>> = makeSingle { map[key]?.status ?: Empty }
 
 	override fun currentKeys(): Single<Set<K>> = makeSingle { map.keys.toSet() }
 

--- a/src/main/kotlin/io/github/snarks/reactivestore/store/StoreSink.kt
+++ b/src/main/kotlin/io/github/snarks/reactivestore/store/StoreSink.kt
@@ -20,7 +20,7 @@ import io.github.snarks.reactivestore.utils.Keyed
 import io.github.snarks.reactivestore.utils.Loader
 import io.github.snarks.reactivestore.utils.Updater
 
-interface StoreSink<in K, V> {
+interface StoreSink<in K, in V> {
 	fun update(key: K, updater: Updater<V>)
 }
 
@@ -72,10 +72,8 @@ fun <K, V> StoreSink<K, V>.reload(
 	update(key, Updater.reload(customLoader, ignoreIfUpdated))
 }
 
-fun <K, V> StoreSink<K, V>.cancelLoad(key: K) {
-	update(key, Updater.cancelLoad())
+fun <K, V> StoreSink<K, V>.revert(key: K) {
+	update(key, Updater.revert())
 }
 
-fun <K, V> StoreSink<K, V>.resetError(key: K) {
-	update(key, Updater.resetError())
-}
+// TODO mapping functions

--- a/src/main/kotlin/io/github/snarks/reactivestore/utils/Loader.kt
+++ b/src/main/kotlin/io/github/snarks/reactivestore/utils/Loader.kt
@@ -24,10 +24,12 @@ typealias Loader<T> = Maybe<T>
 typealias LoadSource<T> = MaybeSource<T>
 
 fun <T> Loader<T>.asFutureChange(): Single<ImmediateChange<T>> = map<ImmediateChange<T>> { SetValue(it) }
-		.toSingle(ClearValue())
+		.toSingle(ClearValue)
 		.onErrorReturn { Fail(it) }
 
-inline fun <T> Loader<T>.asFutureUpdater(crossinline condition: UpdateCondition<T>): Single<Updater<T>> =
+fun <T> Loader<T>.asFutureUpdater(): Single<Updater<T>> = asFutureChange().map { Updater.change(it) }
+
+inline fun <T> Loader<T>.asFutureUpdater(crossinline condition: (Status<*>) -> Boolean): Single<Updater<T>> =
 		asFutureChange().map { Updater.changeIf(it, condition) }
 
 fun <T> LoadSource<T>.toLoader(): Loader<T> = Maybe.wrap(this)


### PR DESCRIPTION
This will allow us to make mapping functions for CacheSink & StoreSink.

- Removed the `default` loader parameter
- Changed `current` parameter from Status<T> -> Status<*>
- Merged `cancelLoad` & `resetFailure` updaters to `revert` updater
- Made Defer.future nullable (if null, it will default to the store's default loader)