### PR TITLE
Include missing Apache License notices

### DIFF
--- a/src/main/kotlin/io/github/snarks/reactivestore/cache/Cache.kt
+++ b/src/main/kotlin/io/github/snarks/reactivestore/cache/Cache.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 James Cruz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.snarks.reactivestore.cache
 
 interface Cache<T> : CacheSink<T>, CacheSource<T>

--- a/src/main/kotlin/io/github/snarks/reactivestore/cache/CacheSink.kt
+++ b/src/main/kotlin/io/github/snarks/reactivestore/cache/CacheSink.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 James Cruz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.snarks.reactivestore.cache
 
 import io.github.snarks.reactivestore.utils.Loader

--- a/src/main/kotlin/io/github/snarks/reactivestore/cache/CacheSource.kt
+++ b/src/main/kotlin/io/github/snarks/reactivestore/cache/CacheSource.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 James Cruz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.snarks.reactivestore.cache
 
 import io.github.snarks.reactivestore.utils.Loaded

--- a/src/main/kotlin/io/github/snarks/reactivestore/cache/ScheduledCacheSource.kt
+++ b/src/main/kotlin/io/github/snarks/reactivestore/cache/ScheduledCacheSource.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 James Cruz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.snarks.reactivestore.cache
 
 import io.github.snarks.reactivestore.utils.Status

--- a/src/main/kotlin/io/github/snarks/reactivestore/cache/SimpleCache.kt
+++ b/src/main/kotlin/io/github/snarks/reactivestore/cache/SimpleCache.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 James Cruz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.snarks.reactivestore.cache
 
 import io.github.snarks.reactivestore.utils.Loader

--- a/src/main/kotlin/io/github/snarks/reactivestore/store/ListingStore.kt
+++ b/src/main/kotlin/io/github/snarks/reactivestore/store/ListingStore.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 James Cruz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.snarks.reactivestore.store
 
 import io.github.snarks.reactivestore.utils.Keyed


### PR DESCRIPTION
Affected files:
- `Cache.kt`
- `CacheSink.kt`
- `CacheSource.kt`
- `ScheduledCacheSource.kt`
- `SimpleCache.kt`
- `ListingStore.kt`